### PR TITLE
Fix Bug in Parse Relation add method

### DIFF
--- a/src/ParseRelation.js
+++ b/src/ParseRelation.js
@@ -82,7 +82,7 @@ export default class ParseRelation {
     var change = new RelationOp(objects, []);
     this.parent.set(this.key, change);
     this.targetClassName = change._targetClassName;
-    return parent;
+    return this.parent;
   }
 
   /**


### PR DESCRIPTION
Error description:

*/node_modules/parse/lib/node/ParseRelation.js:101
      return parent;
             ^

ReferenceError: parent is not defined